### PR TITLE
Add PR preview and testing trigger workflows

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,54 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: legalesign/ls-document-viewer-testing
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Create/update preview branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="pr-${{ github.event.pull_request.number }}"
+          git checkout -B "$BRANCH"
+          git commit --allow-empty -m "preview: ls-document-viewer PR #${{ github.event.pull_request.number }} ($(date -u +%Y-%m-%dT%H:%M:%SZ))"
+          git push origin "$BRANCH" --force
+
+      - name: Post preview URL comment
+        if: github.event.action == 'opened'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const amplifyAppId = process.env.AMPLIFY_APP_ID || '<amplify_app_id>';
+            const previewUrl = `https://pr-${prNumber}.${amplifyAppId}.amplifyapp.com`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `🚀 **Preview deployment**\n\nA preview of this PR will be available at:\n${previewUrl}\n\n_Note: The build may take a few minutes to complete._`
+            });
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: legalesign/ls-document-viewer-testing
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Delete preview branch
+        run: |
+          BRANCH="pr-${{ github.event.pull_request.number }}"
+          git push origin --delete "$BRANCH" || true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -30,7 +30,7 @@ jobs:
           github-token: ${{ secrets.PAT_TOKEN }}
           script: |
             const prNumber = context.payload.pull_request.number;
-            const amplifyAppId = process.env.AMPLIFY_APP_ID || '<amplify_app_id>';
+            const amplifyAppId = 'd25xecos8zk1f0';
             const previewUrl = `https://pr-${prNumber}.${amplifyAppId}.amplifyapp.com`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/trigger-testing.yml
+++ b/.github/workflows/trigger-testing.yml
@@ -1,0 +1,18 @@
+name: Trigger Testing App Rebuild
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to ls-document-viewer-testing
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/legalesign/ls-document-viewer-testing/dispatches \
+            -d '{"event_type": "ls-document-viewer-updated"}'


### PR DESCRIPTION
Add two GitHub Actions workflows: PR Preview creates/updates a preview branch in legalesign/ls-document-viewer-testing for opened/synchronized PRs, posts a comment with the Amplify preview URL, and deletes the branch when the PR is closed; Trigger Testing dispatches a repository_dispatch event to legalesign/ls-document-viewer-testing on pushes to main to trigger a rebuild. Both workflows use the PAT_TOKEN secret for authentication.