### PR TITLE
CON-2035: Update box-sizing

### DIFF
--- a/src/components/ls-document-viewer/ls-document-viewer.scss
+++ b/src/components/ls-document-viewer/ls-document-viewer.scss
@@ -5,6 +5,12 @@
   box-sizing: border-box;
 }
 
+/* Preserve content-box for editor fields — their width/height is set
+   directly via inline styles and a 2px border must NOT eat into that. */
+ls-editor-field {
+  box-sizing: content-box;
+}
+
 /* 2. Remove default margin */
 * {
   margin: 0;


### PR DESCRIPTION
Updated box-sizing for ls-editor-field to be content-box It needs to be explicitly set because of the shadow DOM and consuming app * target Now all fields would have it as content-box