### PR TITLE
BREAKING CHANGE: Release 1.0.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -209,7 +209,8 @@ the validate event.
 const editor = document.querySelector('ls-document-viewer');
 
 editor.addEventListener('validate', (event) => {
-  console.log('Template validation changed:', event.detail.valid);
+  console.log('Template valid:', event.detail.valid);
+  console.log('Validation errors:', event.detail.errors);
 });
 ```
 
@@ -233,8 +234,13 @@ Fired when the document template is changed, such as adding or removing fields. 
 the event that caused it but also the updated state of the template object as JSON.
 
 #### `validate` event
-Fired when the document template is changed, the `valid` property in detail shows if the
-template has become valid or invalid.
+Fired when the document template is changed. The detail includes:
+- `valid` (boolean) — whether the template is valid and ready to send
+- `errors` (array) — list of validation errors, each with:
+  - `type` — `'signature'` | `'options'` | `'value'`
+  - `title` — human-readable error title
+  - `description` — detailed error description
+  - `signerIndex` — the affected signer index
 
 #### `selectFields` event
 Fired when a field is selected in the editor.

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -9,9 +9,9 @@ import { LSApiRole, LSApiRoleType } from "./types/LSApiRole";
 import { LSApiTemplate } from "./types/LSApiTemplate";
 import { LSMutateEvent } from "./types/LSMutateEvent";
 import { LSApiElement } from "./types/LSApiElement";
+import { ValidationError } from "./types/ValidationError";
 import { unknown as Icon, LSApiElement as LSApiElement1, LSApiTemplate as LSApiTemplate1, LsDocumentViewer as LsDocumentViewer1, LSMutateEvent as LSMutateEvent1 } from "./components";
 import { LsDocumentViewer } from "./components/ls-document-viewer/ls-document-viewer";
-import { ValidationError } from "./types/ValidationError";
 import { IToolboxField } from "./components/interfaces/IToolboxField";
 import { LSApiRecipient } from "./types/LSApiRecipient";
 import { Icon as Icon1 } from "./types/Icon";
@@ -19,9 +19,9 @@ export { LSApiRole, LSApiRoleType } from "./types/LSApiRole";
 export { LSApiTemplate } from "./types/LSApiTemplate";
 export { LSMutateEvent } from "./types/LSMutateEvent";
 export { LSApiElement } from "./types/LSApiElement";
+export { ValidationError } from "./types/ValidationError";
 export { unknown as Icon, LSApiElement as LSApiElement1, LSApiTemplate as LSApiTemplate1, LsDocumentViewer as LsDocumentViewer1, LSMutateEvent as LSMutateEvent1 } from "./components";
 export { LsDocumentViewer } from "./components/ls-document-viewer/ls-document-viewer";
-export { ValidationError } from "./types/ValidationError";
 export { IToolboxField } from "./components/interfaces/IToolboxField";
 export { LSApiRecipient } from "./types/LSApiRecipient";
 export { Icon as Icon1 } from "./types/Icon";
@@ -904,7 +904,7 @@ declare global {
         "selectFields": LSApiElement[];
         "mutate": LSMutateEvent[];
         "update": { event: LSMutateEvent; template: LSApiTemplate };
-        "validate": { valid: boolean };
+        "validate": { valid: boolean; errors: ValidationError[] };
         "addParticipant": { name?: string | null; type: LSApiRoleType; parent?: string | null; signerIndex?: number };
     }
     /**
@@ -1638,7 +1638,7 @@ declare namespace LocalJSX {
         "onPageRendered"?: (event: LsDocumentViewerCustomEvent<number>) => void;
         "onSelectFields"?: (event: LsDocumentViewerCustomEvent<LSApiElement[]>) => void;
         "onUpdate"?: (event: LsDocumentViewerCustomEvent<{ event: LSMutateEvent; template: LSApiTemplate }>) => void;
-        "onValidate"?: (event: LsDocumentViewerCustomEvent<{ valid: boolean }>) => void;
+        "onValidate"?: (event: LsDocumentViewerCustomEvent<{ valid: boolean; errors: ValidationError[] }>) => void;
         /**
           * @default 1
          */

--- a/src/components/ls-document-viewer/ls-document-viewer.scss
+++ b/src/components/ls-document-viewer/ls-document-viewer.scss
@@ -5,6 +5,12 @@
   box-sizing: border-box;
 }
 
+/* Preserve content-box for editor fields — their width/height is set
+   directly via inline styles and a 2px border must NOT eat into that. */
+ls-editor-field {
+  box-sizing: content-box;
+}
+
 /* 2. Remove default margin */
 * {
   margin: 0;

--- a/src/components/ls-document-viewer/ls-document-viewer.tsx
+++ b/src/components/ls-document-viewer/ls-document-viewer.tsx
@@ -275,7 +275,7 @@ export class LsDocumentViewer {
   @Event() update: EventEmitter<{ event: LSMutateEvent; template: LSApiTemplate }>;
 
   // Send an external validation event to be monitored by an external developer
-  @Event() validate: EventEmitter<{ valid: boolean }>;
+  @Event() validate: EventEmitter<{ valid: boolean; errors: ValidationError[] }>;
 
   @Event({
     bubbles: true,
@@ -856,7 +856,7 @@ export class LsDocumentViewer {
     }
 
     this.validationErrors = validate.bind(this)(this._template);
-    this.validate.emit({ valid: this.validationErrors.length === 0 });
+    this.validate.emit({ valid: this.validationErrors.length === 0, errors: this.validationErrors });
   }
 
   initViewer() {
@@ -970,7 +970,7 @@ export class LsDocumentViewer {
 
       //Revalidate
       this.validationErrors = validate.bind(this)(this._template);
-      this.validate.emit({ valid: this.validationErrors.length === 0 });
+      this.validate.emit({ valid: this.validationErrors.length === 0, errors: this.validationErrors });
       this.pageCount = this._template.pageCount;
       this.selected = [];
       this.setZoom(1.0);


### PR DESCRIPTION
BREAKING CHANGE (to update version to 1.0.0):
Fixed field box-sizing so the value text is not clipped in the consuming app 
Updated validate emitter to pass the error type 